### PR TITLE
Added order of the pokemon in pokedex in description of the pokemon

### DIFF
--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -19,5 +19,6 @@ export interface Pokemon {
                 front_default: string,
             }
         }
-    }
+    },
+    order: number
 }

--- a/src/pages/[pokemon].tsx
+++ b/src/pages/[pokemon].tsx
@@ -41,7 +41,7 @@ export default function PokemonDetailsPage() {
         {pokemon === null && <p>Pokemon not found</p>}
         {pokemon && (
           <>
-            <h1 className="text-center text-capitalize">{pokemon.name}</h1>
+            <h1 className="text-center text-capitalize">{pokemon.name}  #{pokemon.order}</h1>
             <Image
               src={pokemon.sprites.other["official-artwork"].front_default}
               alt={"Pokemon: " + pokemon.name}


### PR DESCRIPTION
I think it is necessary to add the order number of the pokemon displayed in the pokemon description but I don't know if it is good or not, I will create the PR so you can see it

![image](https://github.com/theashu02/Poke_Dex/assets/41254151/52cdd7ff-637b-4ce8-ae25-40c23dccaf2e)
